### PR TITLE
Allow failure with missing message and type attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.30'
-    id "com.github.johnrengelman.shadow" version "6.0.0"
+    id 'org.jetbrains.kotlin.jvm' version '2.0.21'
+    id "com.gradleup.shadow" version "8.3.0"
     id "io.codearte.nexus-staging" version "0.30.0"
-    id "org.jetbrains.dokka" version "1.4.30"
+    id "org.jetbrains.dokka" version "2.0.0-Beta"
 }
 
 repositories {
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.30"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.0.21"
     implementation "systems.danger:danger-kotlin-sdk:1.2"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.12.2"
 
@@ -20,10 +20,10 @@ dependencies {
 }
 
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "21"
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "21"
 }
 
 // publishing

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 08 18:13:48 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+#Tue Nov 05 17:22:03 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/src/main/kotlin/io/github/ackeecz/danger/junit/JUnitPlugin.kt
+++ b/src/main/kotlin/io/github/ackeecz/danger/junit/JUnitPlugin.kt
@@ -96,8 +96,8 @@ internal data class TestCase(
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 internal data class Failure(
-    @field:JacksonXmlProperty val message: String = "",
-    @field:JacksonXmlProperty val type: String = "",
+    @field:JacksonXmlProperty(isAttribute = true) val message: String = "",
+    @field:JacksonXmlProperty(isAttribute = true) val type: String = "",
     @field:JacksonXmlText val body: String = ""
 )
 

--- a/src/test/kotlin/io/github/ackeecz/danger/junit/JUnitPluginTests.kt
+++ b/src/test/kotlin/io/github/ackeecz/danger/junit/JUnitPluginTests.kt
@@ -17,6 +17,30 @@ class JUnitPluginTests {
         // then
         Truth.assertThat(dangerContext.markdowns)
             .isNotEmpty()
+        Truth.assertThat(dangerContext.markdowns.first().toString())
+            .isEqualTo(
+                """
+                    Violation(message=### Tests: 
+    
+                    #### cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest
+                    
+                    | File | Name |
+                    | ---- | ---- |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should show article detail with topics section of max topics and no expanded button |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should show article detail without similar articles |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should show article detail with similar articles |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | display not downloaded info text when saved article and article dont have text |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should show article detail with topics section expanded |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should show article detail without image |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should show article detail with topics section and expanded button |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should show article detail without topics section |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should show article detail with topics section of less than max topics and no expanded button |
+                    | cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest | should handle empty message and type parameters |
+                    
+                    
+                    , file=null, line=null)
+                """.trimIndent()
+            )
     }
 
     @Test

--- a/src/test/resources/test_failures.xml
+++ b/src/test/resources/test_failures.xml
@@ -240,6 +240,31 @@
 			at java.lang.Thread.run(Thread.java:748)
 		</failure>
 	</testcase>
+	<testcase name="should handle empty message and type parameters"
+		classname="cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest" time="0.046">
+		<failure>java.lang.AssertionError
+			at org.junit.Assert.fail(Assert.java:86)
+			at org.junit.Assert.assertTrue(Assert.java:41)
+			at org.junit.Assert.assertTrue(Assert.java:52)
+			at cz.flashsport.saved.screens.articledetail.detail.ArticleDetailControllerTest.should show article detail
+			with topics section of less than max topics and no expanded button(ArticleDetailControllerTest.kt:73)
+			at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+			at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+			at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+			at java.lang.reflect.Method.invoke(Method.java:498)
+			at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
+			at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
+			at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
+			at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
+			at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:546)
+			at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$0(SandboxTestRunner.java:252)
+			at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:89)
+			at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+			at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+			at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+			at java.lang.Thread.run(Thread.java:748)
+		</failure>
+	</testcase>
 	<system-out><![CDATA[WARNING: No manifest file found at ./AndroidManifest.xml.
 Falling back to the Android OS resources only.
 To remove this warning, annotate your test class with @Config(manifest=Config.NONE).


### PR DESCRIPTION
I found it difficult to find any sort of official specification of the Junit XML format, but [this Stack Overflow answer](https://stackoverflow.com/a/9410271) shows that the `message` and `type` attributes on failures are optional:

```xml
...
    <xs:element name="failure">
        <xs:complexType mixed="true">
            <xs:attribute name="type" type="xs:string" use="optional"/>
            <xs:attribute name="message" type="xs:string" use="optional"/>
        </xs:complexType>
    </xs:element>
...
```

This PR updates the XML parsing to follow that specification. It also updates dependencies so they can be built with the latest version of Android Studio, and makes the test around parsing failures more comprehensive.